### PR TITLE
Increase z-index of .msw-toolbar

### DIFF
--- a/src/component/styles.module.css
+++ b/src/component/styles.module.css
@@ -11,7 +11,7 @@
 }
 
 .msw-toolbar {
-  @apply fixed inset-x-0 z-50 flex p-2 bg-gray-100 overflow-hidden transition;
+  @apply fixed inset-x-0 z-[9999] flex p-2 bg-gray-100 overflow-hidden transition;
 }
 
 .msw-toolbar[data-position='top'] {


### PR DESCRIPTION
Currently it gets stuck behind the sidebar 
<img width="750" alt="image" src="https://github.com/stordco/msw-toolbar/assets/8014423/817a55dc-bdd4-4afa-94ef-c2b5ad491048">